### PR TITLE
Fix checking the server connection status

### DIFF
--- a/scripts/Env.gd
+++ b/scripts/Env.gd
@@ -272,9 +272,12 @@ func connect_to_server(ip, port):
 	client = StreamPeerTCP.new()
 	
 	var connect = client.connect_to_host(ip, port)
+	if connect != OK:
+		print("Failed connecting to sever!")
 	
-	print(connect, client.get_status())
-	return client.get_status() == 2
+	var connected = client.is_connected_to_host()
+	print("Connected: ", connected)
+	return connected
 
 func _send_dict_as_json_message(dict):
 	client.put_string(to_json(dict))


### PR DESCRIPTION
The proper way is to check the result of the `connect_to_host(...)` instead of the client's status.

Both `OK [==2]` and `Connecting [== 1]` status values are considered ok.